### PR TITLE
feat: add GitHub issue templates for bugs, features, and questions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,50 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: '[BUG] '
+labels: ['bug']
+assignees: ''
+---
+
+## Bug Description
+<!-- A clear and concise description of what the bug is -->
+
+## Steps to Reproduce
+<!-- Steps to reproduce the behavior -->
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+## Expected Behavior
+<!-- A clear and concise description of what you expected to happen -->
+
+## Actual Behavior
+<!-- A clear and concise description of what actually happened -->
+
+## Screenshots
+<!-- If applicable, add screenshots to help explain your problem -->
+
+## Environment
+**Desktop:**
+- OS: [e.g. Windows 10, macOS 12.1, Ubuntu 20.04]
+- Browser: [e.g. Chrome 98, Firefox 97, Safari 15]
+- Version: [e.g. 1.2.3]
+
+**Mobile:**
+- Device: [e.g. iPhone 13, Samsung Galaxy S21]
+- OS: [e.g. iOS 15.1, Android 12]
+- Browser: [e.g. Safari, Chrome, Samsung Internet]
+- Version: [e.g. 1.2.3]
+
+## Additional Context
+<!-- Add any other context about the problem here -->
+
+## Console Errors
+<!-- If applicable, paste any console errors or logs -->
+```
+Paste console errors here
+```
+
+## Possible Solution
+<!-- If you have ideas on how to fix this, please share them -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,44 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: '[FEATURE] '
+labels: ['enhancement']
+assignees: ''
+---
+
+## Feature Summary
+<!-- A clear and concise description of the feature you'd like to see -->
+
+## Problem Statement
+<!-- Is your feature request related to a problem? Please describe -->
+<!-- Example: I'm always frustrated when [...] -->
+
+## Proposed Solution
+<!-- A clear and concise description of what you want to happen -->
+
+## Alternative Solutions
+<!-- A clear and concise description of any alternative solutions you've considered -->
+
+## Use Cases
+<!-- Describe specific use cases for this feature -->
+1. As a [user type], I want to [action] so that [benefit]
+2. As a [user type], I want to [action] so that [benefit]
+
+## Acceptance Criteria
+<!-- Define what "done" looks like for this feature -->
+- [ ] Criteria 1
+- [ ] Criteria 2
+- [ ] Criteria 3
+
+## Additional Context
+<!-- Add any other context, mockups, or screenshots about the feature request here -->
+
+## Implementation Notes
+<!-- If you have ideas about how this could be implemented, share them here -->
+
+## Priority
+<!-- How important is this feature to you? -->
+- [ ] Low - Nice to have
+- [ ] Medium - Would improve workflow
+- [ ] High - Blocking current work
+- [ ] Critical - Urgent need

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,34 @@
+---
+name: Question
+about: Ask a question about the project
+title: '[QUESTION] '
+labels: ['question']
+assignees: ''
+---
+
+## Question
+<!-- What would you like to know? -->
+
+## Context
+<!-- Provide context about what you're trying to achieve -->
+
+## What I've Tried
+<!-- What have you already attempted? -->
+- [ ] Searched existing issues
+- [ ] Read the documentation
+- [ ] Searched online
+- [ ] Other: 
+
+## Environment (if relevant)
+- OS: [e.g. Windows 10, macOS 12.1, Ubuntu 20.04]
+- Node.js version: [e.g. 16.14.0]
+- Project version: [e.g. 1.2.3]
+
+## Code Example (if applicable)
+<!-- Provide a minimal code example that demonstrates your question -->
+```javascript
+// Your code here
+```
+
+## Expected Outcome
+<!-- What are you hoping to achieve? -->


### PR DESCRIPTION
# Pull Request

## Changes

I've been created templates for issues like bugs, features and questions.

## Type of Change
*Put an 'x' in the boxes that apply*
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):